### PR TITLE
[vsashidh] Issue #49 : internet explorer instance not stopping

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -23,6 +23,7 @@ function Instance( options ) {
 	this.image = options.image;
 	this.processName = options.processName;
 	this.tempDir = options.tempDir;
+	this.browserType = options.type; //saving the type of browser instance for issue# 49
 
 	this.process = child.spawn( this.command, this.args, {
 		detached: options.detached,
@@ -65,6 +66,10 @@ Instance.prototype.stop = function( callback ) {
 	// Opera case - it uses a launcher so we have to kill it somehow without a reference to the process
 	if ( process.platform === 'win32' && this.image ) {
 		child.exec( 'taskkill /F /IM ' + this.image )
+			.on( 'exit', this.emit.bind( this, 'stop' ) );
+		// ie case on windows machine
+	} else if ( process.platform === 'win32' && this.browserType === 'ie' ) {
+		child.exec( 'taskkill /F /IM iexplore.exe')
 			.on( 'exit', this.emit.bind( this, 'stop' ) );
 		// OSX case with "open" command
 	} else if ( this.command === 'open' ) {


### PR DESCRIPTION
I'm a little concerned about _why_ the instance wasn't stopping properly. Note that if you run `example/launch.js` with IE, it shows the following:

```
$ node launch.js
Instance started with PID: 3168
Instance stopped with exit code: 1
Instance stopped with exit code: 0
```

What's with the `exit code: 1` in the middle? Hmm. (That existed before this PR, it's just curious)
