### PR TITLE
Use old win-detect-browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 1.2.1
 
 #### Bugfixes
-- #21 `detect` works on OSX again
+- #21 `detect` works on OSX again (i: @mitchhentges, r: @tomitm)
 
 ## 1.2.0
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mkdirp": "^0.5.0",
     "osenv": "^0.1.0",
     "plist": "^1.0.1",
-    "win-detect-browsers": "^2.1.0",
+    "win-detect-browsers": "1.0.2",
     "uid": "0.0.2",
     "rimraf": "~2.5.2"
   },


### PR DESCRIPTION
This will allow browserify/electron compatibility again
