### PR TITLE
Provide spawn error in callback

### DIFF
--- a/lib/detect.js
+++ b/lib/detect.js
@@ -57,8 +57,13 @@ function checkDarwin(name, callback) {
  * @param {Function} callback Callback function
  */
 function getCommandVersion(name, regex, callback) {
-    var process = spawn(name, ['--version']),
-        data = '';
+    try {
+        var process = spawn(name, ['--version']);
+    } catch ( e ) {
+        callback( e );
+    }
+
+    var data = '';
 
     process.stdout.on('data', function (buf) {
         data += buf;

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -60,7 +60,7 @@ function getCommandVersion(name, regex, callback) {
     try {
         var process = spawn(name, ['--version']);
     } catch ( e ) {
-        callback( e );
+        return callback( e );
     }
 
     var data = '';

--- a/lib/run.js
+++ b/lib/run.js
@@ -284,12 +284,16 @@ module.exports = function runBrowser( config, name, version ) {
 
 				browser.tempDir = options.tempDir;
 
-				callback( null, new Instance( assign( {}, browser, {
-					args: args,
-					detached: options.detached,
-					env: env,
-					cwd: cwd
-				} ) ) );
+                try {
+                    callback(null, new Instance( assign( {}, browser, {
+                        args: args,
+                        detached: options.detached,
+                        env: env,
+                        cwd: cwd
+                    })));
+                } catch ( e ) {
+                    callback( e )
+                }
 			} );
 		}
 	};


### PR DESCRIPTION
See the original issue reported to `browser-launcher2`: https://github.com/benderjs/browser-launcher2/issues/53.
This should also fix [this Sentry report we keep getting on James](https://sentry.fuzzlesoft.ca/share/issue/342e34/)
