### PR TITLE
Fix Chrome launch not passed --proxy-server flag.

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -177,7 +177,7 @@ setups.ie = setups.safari = function (browser, options, callback) {
 setups.chrome = function (browser, options, callback) {
   options.options = options.options || [];
   options.options.push(browser.profile ? '--user-data-dir=' + browser.profile : null);
-  if (options.options.proxy) {
+  if (options.proxy) {
     options.options.push('--proxy-server=' + options.proxy);
   }
 


### PR DESCRIPTION
Just a typo during 1.2.4 refactoring. Resulted in Chrome never being passed the `--proxy-server` flag.
