### PR TITLE
Revert "Fix Mac OS X browser launching"

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -333,32 +333,28 @@ module.exports = function runBrowser(config, name, version) {
         // prepare the launch command for OSX systems
         if (process.platform === 'darwin') {
           // use the binary paths under the hood
-          // open --wait-apps --new --fresh -a /Path/To/Executable <url> --args <rest of app args>
-          if (browser.name === 'chrome') {
-            args.unshift(uri);
+          if (browser.name !== 'firefox' && browser.name !== 'phantomjs') {
+            // open --wait-apps --new --fresh -a /Path/To/Executable <url> --args <rest of app args>
+            args.unshift(
+              '--wait-apps',
+              '--new',
+              '--fresh',
+              '-a',
+              browser.command,
+              args.pop(),
+              '--args'
+            );
+
+            browser.processName = browser.command;
+            browser.command = 'open';
           }
-
-          args.unshift(
-            '--wait-apps',
-            '--new',
-            '--fresh',
-            '-a',
-            browser.command,
-            uri,
-            '--args'
-          );
-
-          browser.processName = browser.command;
-          browser.command = 'open';
-        } else {
-          args = args.unshift(uri);
         }
 
         browser.tempDir = options.tempDir;
 
         try {
           callback(null, new Instance(assign({}, browser, {
-            args: args.filter(Boolean),
+            args: args.filter(Boolean).concat(uri),
             detached: options.detached,
             env: env,
             cwd: cwd


### PR DESCRIPTION
Reverts james-proxy/james-browser-launcher#58 due to regression in launching browsers.
This will put `james-browser-launcher` into it's previous state of `1.2.6`, which _does_ have issues launching browsers on Mac.

I'll release `1.2.8` that is identical to `1.2.6` to avoid issues for existing, content consumers of `james-browser-launcher`

I'll release this PR (and its associated fix) in a `1.3.0` release, so that Marcelo has a release that works with Mac.