### PR TITLE
Improves quoting on "noProxy" options passed to browsers

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -145,7 +145,7 @@ setups.firefox = function (browser, options, callback) {
       'network.proxy.http': host,
       'network.proxy.http_port': +port,
       'network.proxy.type': 1,
-      'network.proxy.no_proxies_on': formatNoProxyStandard(options)
+      'network.proxy.no_proxies_on': '"' + formatNoProxyStandard(options) + '"'
     });
   }
 
@@ -199,7 +199,7 @@ setups.chrome = function (browser, options, callback) {
 
   var noProxy = formatNoProxyChrome(options);
   if (noProxy) {
-    options.options.push('--proxy-bypass-list="' + noProxy + '"');
+    options.options.push('--proxy-bypass-list=' + noProxy);
   }
 
   var defaults = [


### PR DESCRIPTION
For Firefox prefs, quotes are needed around strings, such as our list of domains.
In the same vein, we don't need to put double-quotes around values with spaces for process arguments if they're already separated into an array, such as the case for Chrome's options.

@mfgea, would you mind confirming that this PR's changes still properly affect the "no-proxy" functionality of Chrome and Firefox?