### PR TITLE
Allow overriding the default browser profile directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Open given URI in a browser and return an instance of it.
 - *Boolean* `options.detached` - if true, then killing your script will not kill the opened browser
 - *Array|String* `options.noProxy` - An array of strings, containing proxy routes to skip over
 - *Boolean* `options.headless` - run a browser in a headless mode (only if **Xvfb** available)
+- *String* `options.profile` - path to a directory to use for the browser profile, overriding the default
 - *Function* `callback(err, instance)` - function fired when started a browser `instance` or an error occurred
 
 ### `launch.browsers`

--- a/lib/run.js
+++ b/lib/run.js
@@ -117,8 +117,8 @@ function formatNoProxyChrome(options) {
  */
 setups.firefox = function (browser, options, callback) {
   var id = uid(10);
-  var tempDir = path.join(os.tmpdir(), 'james-browser-launcher' + id);
-  var file = path.join(tempDir, 'prefs.js');
+  var profileDir = options.profile || path.join(os.tmpdir(), 'james-browser-launcher' + id);
+  var file = path.join(profileDir, 'prefs.js');
   var prefs = options.skipDefaults ? {} : {
     'browser.shell.checkDefaultBrowser': false,
     'browser.bookmarks.restore_default_bookmarks': false,
@@ -131,10 +131,12 @@ setups.firefox = function (browser, options, callback) {
     'browser.startup.page': 0
   };
 
-  mkdirp.sync(tempDir);
+  mkdirp.sync(profileDir);
 
   options.options = options.options || [];
-  options.tempDir = tempDir;
+  if (!options.profile) {
+    options.tempDir = profileDir;
+  }
 
   if (options.proxy) {
     var match = /^(?:http:\/\/)?([^:/]+)(?::(\d+))?/.exec(options.proxy);
@@ -159,7 +161,7 @@ setups.firefox = function (browser, options, callback) {
 
   options.options = options.options.concat([
     '--no-remote',
-    '-profile', tempDir
+    '-profile', profileDir
   ]);
 
   fs.writeFile(file, prefs, function (err) {
@@ -192,7 +194,8 @@ setups.ie = setups.safari;
  */
 setups.chrome = function (browser, options, callback) {
   options.options = options.options || [];
-  options.options.push(browser.profile ? '--user-data-dir=' + browser.profile : null);
+  var profile = options.profile || browser.profile;
+  options.options.push(profile ? '--user-data-dir=' + profile : null);
   if (options.proxy) {
     options.options.push('--proxy-server=' + options.proxy);
   }
@@ -272,11 +275,13 @@ setups.opera = function (browser, options, callback) {
   var generation = major(browser.version) >= 15 ? 'blink' : 'old';
   var prefFile = prefs[generation];
   var src = path.join(__dirname, '../res/' + prefFile);
-  var dest = path.join(browser.profile, prefFile);
+
+  var profile = options.profile || browser.profile;
+  var dest = path.join(profile, prefFile);
 
   options.options = options.options || [];
   if (generation === 'blink') {
-    options.options.push(browser.profile ? '--user-data-dir=' + browser.profile : null);
+    options.options.push(profile ? '--user-data-dir=' + profile : null);
   }
 
   copy(src, dest, function (err) {


### PR DESCRIPTION
I need this because the Firefox setup creates a temp folder every time. This fixed https://github.com/benderjs/browser-launcher2/issues/21, because repeatedly killing a firefox instance using a profile folder can corrupt it.

In my case though, I'm launching a Firefox instance that I expect the user to close manually most of the time, so this isn't necessary, and I'd like the profile to persist between runs, which this currently breaks. Being able to override the profile to provide a fixed directory solves this nicely for me, and doesn't change the existing behaviour.

As a bonus, rather than create a firefox-specific option, I've updated all the other setups too, so that you can now override the profile directory everywhere, if you want to for some reason.