### PR TITLE
Detect firefox-nightly

### DIFF
--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -25,7 +25,8 @@ var browserDefinitions = {
     profile: true,
     variants: {
       'firefox': ['firefox'],
-      'firefox-developer': ['firefox-developer']
+      'firefox-developer': ['firefox-developer'],
+      'firefox-nightly': ['firefox-nightly']
     }
   },
   phantomjs: {

--- a/lib/darwin/index.js
+++ b/lib/darwin/index.js
@@ -12,5 +12,6 @@ exports['chrome-canary'] = browser('com.google.Chrome.canary', 'KSVersion');
 exports.chromium = browser('org.chromium.Chromium', 'CFBundleShortVersionString');
 exports.firefox = browser('org.mozilla.firefox', 'CFBundleShortVersionString');
 exports['firefox-developer'] = browser('org.mozilla.firefoxdeveloperedition', 'CFBundleShortVersionString');
+exports['firefox-nightly'] = browser('org.mozilla.nightly', 'CFBundleShortVersionString');
 exports.safari = browser('com.apple.Safari', 'CFBundleShortVersionString');
 exports.opera = browser('com.operasoftware.Opera', 'CFBundleVersion');


### PR DESCRIPTION
[Firefox Nightly](https://wiki.mozilla.org/Nightly) is the nightly build of Firefox. It's distributed as a standalone tarball, so it can in theory could be installed with any name, but many of the published packages (e.g. [for Arch](https://aur.archlinux.org/packages/firefox-nightly/)) put it into your PATH as `firefox-nightly`.

Right now, in that case it isn't detected by james-browser-launcher. This PR fixes that.